### PR TITLE
Change Invoke-Executable to output stdout/stderr in AppVeyor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for PSTestWinibalZ
 
+## v0.1.1 - 2018-07-10
+
+* Modified `Invoke-Executable` to work with the AppVeyor Runspace Host when trying to output the command stdout/stderr
+
 ## v0.1.0 - 2018-07-04
 
 * Initial version for the `PSTestWinibalZ` module

--- a/PSTestWinibleZ/PSTestWinibleZ.psd1
+++ b/PSTestWinibleZ/PSTestWinibleZ.psd1
@@ -3,7 +3,7 @@
 
 @{
     RootModule = 'PSTestWinibleZ.psm1'
-    ModuleVersion = '0.1.0'
+    ModuleVersion = '0.1.1'
     GUID = '7395e601-efc5-4248-8d2e-d1983fbf7204'
     Author = 'Jordan Borean'
     Copyright = 'Copyright (c) 2018 by Jordan Borean, Red Hat, licensed under MIT.'

--- a/PSTestWinibleZ/Public/Test-AnsibleRole.ps1
+++ b/PSTestWinibleZ/Public/Test-AnsibleRole.ps1
@@ -72,7 +72,7 @@ ansible_winrm_transport=ntlm
                 Set-Content -Path $inventory_path -Value $inventory_text
             }
 
-            Enable-PSRemoting -Force
+            Enable-PSRemoting -Force > $null
         }
 
         $build_file = Join-Path -Path $script:PSScriptRoot -ChildPath Resources | Join-Path -ChildPath psake.ps1
@@ -93,4 +93,6 @@ ansible_winrm_transport=ntlm
     if (-not $psake.build_success) {
         Write-Error -Message "psake failed with error, check error logs and fix up build"
     }
+
+    return $psake.build_success
 }


### PR DESCRIPTION
There's an issue when running in AppVeyor with the `System.Diagnostics.Process` not sending the `stderr/stdout` to the Console. This is probably because AppVeyor is running the commands in a Runspace and so the output won't be available. This PR changes it so it will capture the output and send to the runspace's host user interface instead.